### PR TITLE
Added a border-radius 0 property

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -109,6 +109,7 @@ input[type="text"], input[type="text"]:not(:focus) {
   padding: .5em;
   transition: all 500ms ease;
   width: 15em;
+  border-radius: 0px;
 }
 
 input[type="text"]:focus, input[type="text"]:focus::placeholder {


### PR DESCRIPTION
Thought it was weird that the "Search on google" input had rounded borders when not focused, so I added "border-radius: 0;" and it's fixed.
It's a very small, unimportant fix but it looked a bit odd.

Demostration:
Without fix:
![alt text](https://i.gyazo.com/0b87fb9a8f519ebad0f1c87d5e6fa13a.png "without fix")

With fix:
![alt text](https://i.gyazo.com/930455afff799a0c293a3b0201b48fa4.png "with fix")